### PR TITLE
fix: update current requested reviewers list check syntax

### DIFF
--- a/.github/workflows/pr-base.yml
+++ b/.github/workflows/pr-base.yml
@@ -170,7 +170,7 @@ jobs:
           payload: |
             {
               "thread_ts": "${{ steps.get-thread-ts.outputs.thread_ts }}",
-              "text": "${{ contains(github.event.pull_request.requested_reviewers[*].login, github.event.requested_reviewer.login) && format('{0}, you have been requested to re-review this PR', steps.get-slack-id.outputs.new_reviewer) || format('{0} has been added as a reviewer', steps.get-slack-id.outputs.new_reviewer) }}"
+              "text": "${{ contains(github.event.pull_request.requested_reviewers.*.login, github.event.requested_reviewer.login) && format('{0}, you have been requested to re-review this PR', steps.get-slack-id.outputs.new_reviewer) || format('{0} has been added as a reviewer', steps.get-slack-id.outputs.new_reviewer) }}"
             }
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}


### PR DESCRIPTION
With the current setup, when new reviewers are added to a PR, the slack notify workflow sends a message indicating that the a `re-review` has been requested of the reviewer despite the user not having been added before. This appears to be a syntax bug which results in the list of previously added reviewers being incorrectly detected.

![Screenshot from 2025-02-28 14-00-48](https://github.com/user-attachments/assets/b9ad7134-04b1-4da1-86d8-d620b1fadf88)
 