### PR TITLE
chore: bind external github actions to SHA ref

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/pr-base.yml
+++ b/.github/workflows/pr-base.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - name: Generate GitHub App Token
         id: bot_token
-        uses: tibdex/github-app-token@v1
+        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
         with:
           app_id: ${{ secrets.GH_APP_ID }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
@@ -35,7 +35,7 @@ jobs:
 
       - name: Auto-assign PR to author
         if: github.event.action == 'opened' || github.event.action == 'reopened'
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           github-token: ${{ steps.bot_token.outputs.token }}
           script: |
@@ -102,7 +102,7 @@ jobs:
       - name: Send initial Slack notification
         if: (github.event.action == 'opened' || github.event.action == 'reopened' || github.event.action == 'ready_for_review') && !github.event.pull_request.draft
         id: slack-notification
-        uses: slackapi/slack-github-action@v1.24.0
+        uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d # v2.0.0
         with:
           channel-id: ${{ secrets.SLACK_GITHUB_LOGS_CHANNEL_ID }}
           payload: |
@@ -129,7 +129,7 @@ jobs:
 
       - name: Store thread_ts
         if: (github.event.action == 'opened' || github.event.action == 'reopened' || github.event.action == 'ready_for_review') && !github.event.pull_request.draft
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           github-token: ${{ steps.bot_token.outputs.token }}
           script: |
@@ -142,7 +142,7 @@ jobs:
 
       - name: Send reviewer reminder
         if: (github.event.action == 'opened' || github.event.action == 'reopened' || github.event.action == 'ready_for_review') && toJSON(github.event.pull_request.requested_reviewers) == '[]' && steps.slack-notification.outputs.thread_ts != ''
-        uses: slackapi/slack-github-action@v1.24.0
+        uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d # v2.0.0
         with:
           channel-id: ${{ secrets.SLACK_GITHUB_LOGS_CHANNEL_ID }}
           payload: |
@@ -156,7 +156,7 @@ jobs:
       - name: Get thread_ts for reviewer added
         if: github.event.action == 'review_requested'
         id: get-thread-ts-reviewer
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           github-token: ${{ steps.bot_token.outputs.token }}
           script: |
@@ -176,7 +176,7 @@ jobs:
       - name: Check if re-review
         if: github.event.action == 'review_requested'
         id: check-re-review
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           github-token: ${{ steps.bot_token.outputs.token }}
           script: |
@@ -195,7 +195,7 @@ jobs:
 
       - name: Send reviewer added notification
         if: github.event.action == 'review_requested' && steps.get-thread-ts-reviewer.outputs.thread_ts != ''
-        uses: slackapi/slack-github-action@v1.24.0
+        uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d # v2.0.0
         with:
           channel-id: ${{ secrets.SLACK_GITHUB_LOGS_CHANNEL_ID }}
           payload: |
@@ -209,7 +209,7 @@ jobs:
       - name: Get thread_ts for PR close
         if: github.event.action == 'closed'
         id: get-thread-ts-close
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           github-token: ${{ steps.bot_token.outputs.token }}
           script: |
@@ -229,7 +229,7 @@ jobs:
       - name: Send PR state merge/close notification
         if: github.event.action == 'closed' && steps.get-thread-ts-close.outputs.thread_ts != ''
         id: send-close-message
-        uses: slackapi/slack-github-action@v1.24.0
+        uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d # v2.0.0
         with:
           channel-id: ${{ secrets.SLACK_GITHUB_LOGS_CHANNEL_ID }}
           payload: |
@@ -243,7 +243,7 @@ jobs:
       - name: Get thread_ts for review
         if: github.event.action == 'submitted'
         id: get-thread-ts-review
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           github-token: ${{ steps.bot_token.outputs.token }}
           script: |
@@ -262,7 +262,7 @@ jobs:
 
       - name: Send review notification
         if: github.event.action == 'submitted' && (github.event.review.state == 'approved' || github.event.review.state == 'changes_requested') && steps.get-thread-ts-review.outputs.thread_ts != ''
-        uses: slackapi/slack-github-action@v1.24.0
+        uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d # v2.0.0
         with:
           channel-id: ${{ secrets.SLACK_GITHUB_LOGS_CHANNEL_ID }}
           payload: |
@@ -275,7 +275,7 @@ jobs:
 
       - name: Add reaction to main message
         if: github.event.action == 'closed' && steps.get-thread-ts-close.outputs.thread_ts != ''
-        uses: slackapi/slack-github-action@v2.0.0
+        uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d # v2.0.0
         with:
           method: reactions.add
           token: ${{ secrets.SLACK_BOT_TOKEN }}
@@ -286,4 +286,4 @@ jobs:
               "name": "${{ github.event.pull_request.merged == true && 'ship' || 'x' }}"
             }
         env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }} 
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}


### PR DESCRIPTION
## Motivation

see [ENG-574](https://linear.app/otim/issue/ENG-574/enforce-sha-pinning-for-external-github-actions)

## Solution

* bind actions to the SHA git reference associated with the latest version
* add a Dependabot config to initiate dependabot automatic scanning for identifying updates and vulnerability fixes for actions
* while most external Github Actions currently used within this repo are from mainstream/reputable sources and likely to be trusted, the plan is to include static analysis tools like [actionlint](https://github.com/rhysd/actionlint) within CI to scan for vulnerabilities within workflows (similar to how `Slither` is used for protocol contracts) 