### PR TITLE
fix: update slack method technique notification requirements

### DIFF
--- a/.github/workflows/pr-base.yml
+++ b/.github/workflows/pr-base.yml
@@ -277,10 +277,10 @@ jobs:
         if: github.event.action == 'closed' && steps.get-thread-ts-close.outputs.thread_ts != ''
         uses: slackapi/slack-github-action@fcfb566f8b0aab22203f066d80ca1d7e4b5d05b3 # v1.27.1
         with:
-          method: reactions.add
-          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          channel-id: ${{ secrets.SLACK_GITHUB_LOGS_CHANNEL_ID }}
           payload: |
             {
+              "method": "reactions.add",
               "channel": "${{ secrets.SLACK_GITHUB_LOGS_CHANNEL_ID }}",
               "timestamp": "${{ steps.get-thread-ts-close.outputs.thread_ts }}",
               "name": "${{ github.event.pull_request.merged == true && 'ship' || 'x' }}"


### PR DESCRIPTION
* tested using [this](https://otim.slack.com/archives/C08F7FQA5NX/p1744129815233469?thread_ts=1744129813.973759&cid=C08F7FQA5NX) slack thread msg
* the API now seems to (ridiculously) require redundant specification of the channel-id/channel

![Screenshot from 2025-04-08 12-25-38](https://github.com/user-attachments/assets/bbe31daf-39c1-4e78-8774-ee9e9a416d3f)
